### PR TITLE
Bump version and remove Subscription methods

### DIFF
--- a/lib/global_registry/subscription.rb
+++ b/lib/global_registry/subscription.rb
@@ -1,11 +1,4 @@
 module GlobalRegistry
   class Subscription < Base
-    def self.all
-      get_all_pages['subscriptions']
-    end
-
-    def self.create(params)
-      post(subscription: params)
-    end
   end
 end

--- a/lib/global_registry/version.rb
+++ b/lib/global_registry/version.rb
@@ -1,3 +1,3 @@
 module GlobalRegistry
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
These `Subscription` methods aren't correct anymore since `get_all_pages` is now an instance variable (forgot to remove them before).

Also, it seems that the RubyGems versioning: http://guides.rubygems.org/patterns/#semantic-versioning would say that you should bump the minor version for adding non-breaking new methods so this bumps it to `1.3.0`.
