### PR TITLE
Allow a Proxy URL to be Set

### DIFF
--- a/lib/global_registry.rb
+++ b/lib/global_registry.rb
@@ -7,7 +7,7 @@ end
 
 module GlobalRegistry
   class << self
-    attr_accessor :base_url, :access_token
+    attr_accessor :base_url, :access_token, :proxy_url
 
     def configure
       yield self

--- a/lib/global_registry/base.rb
+++ b/lib/global_registry/base.rb
@@ -81,18 +81,25 @@ module GlobalRegistry
       case method
       when :post
         post_headers = default_headers.merge(content_type: :json, timeout: nil).merge(headers)
-        RestClient.post(url.to_s, params.to_json, post_headers) { |response, request, result, &block|
+        post_args = { method: method, url: url.to_s, timeout: nil, params: params.to_json,
+                      headers: post_headers, proxy: GlobalRegistry.proxy_url
+                    }
+        RestClient::Request.execute(post_args) { |response, request, result, &block|
           handle_response(response, request, result)
         }
       when :put
         put_headers = default_headers.merge(content_type: :json, timeout: nil).merge(headers)
-        RestClient.put(url.to_s, params.to_json, put_headers) { |response, request, result, &block|
+        put_args = { method: method, url: url.to_s, timeout: nil, params: params.to_json,
+                     headers: put_headers, proxy: GlobalRegistry.proxy_url
+                   }
+        RestClient::Request.execute(put_args) { |response, request, result, &block|
           handle_response(response, request, result)
         }
       else
         url.query_values = (url.query_values || {}).merge(params) if params.any?
         get_args = { method: method, url: url.to_s, timeout: nil,
-                     headers: default_headers.merge(headers)
+                     headers: default_headers.merge(headers),
+                     proxy: GlobalRegistry.proxy_url
                    }
         RestClient::Request.execute(get_args) { |response, request, result, &block|
           handle_response(response, request, result)


### PR DESCRIPTION
This allows a services hosted on a dynamic IP address to be proxied through
a service with a static IP in order to be whitelisted for GR. An example
would be a service hosted on Heroku that needs to utilize GR.

Initially implemented to support GrowthSpaces.