### PR TITLE
Allow newer versions of OJ gem

### DIFF
--- a/global_registry.gemspec
+++ b/global_registry.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('rest-client', '>= 1.6.7', '< 3.0.0')
-  gem.add_dependency('oj', '~> 2.13')
+  gem.add_dependency('oj', '>= 2.13')
   gem.add_dependency('oj_mimic_json')
   gem.add_dependency('activesupport')
   gem.add_dependency('retryable-rb', '~> 1.1')

--- a/lib/global_registry/version.rb
+++ b/lib/global_registry/version.rb
@@ -1,3 +1,3 @@
 module GlobalRegistry
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
The ougai logging gem requires oj to be a newer version