### PR TITLE
Raising custom exceptions for REST errors.

### DIFF
--- a/lib/global_registry.rb
+++ b/lib/global_registry.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/string/inflections'
 require 'global_registry/base'
+require 'global_registry/exceptions'
 
 Dir[File.dirname(__FILE__) + '/global_registry/*.rb'].each do |file|
   require file

--- a/lib/global_registry/base.rb
+++ b/lib/global_registry/base.rb
@@ -121,15 +121,15 @@ module GlobalRegistry
       when 200..299
         Oj.load(response)
       when 400
-        raise RestClient::BadRequest, response
+        raise GlobalRegistry::BadRequest, response
       when 404
-        raise RestClient::ResourceNotFound, response
+        raise GlobalRegistry::ResourceNotFound, response
       when 500
-        raise RestClient::InternalServerError, response
+        raise GlobalRegistry::InternalServerError, response
       else
         puts response.inspect
         puts request.inspect
-        raise result.to_s
+        raise GlobalRegistry::OtherError, response
       end
     end
 

--- a/lib/global_registry/exceptions.rb
+++ b/lib/global_registry/exceptions.rb
@@ -1,0 +1,6 @@
+module GlobalRegistry #:nodoc:
+  class BadRequest < ::RestClient::BadRequest; end
+  class ResourceNotFound < ::RestClient::ResourceNotFound; end
+  class InternalServerError < ::RestClient::InternalServerError; end
+  class OtherError < ::RestClient::Exception; end
+end

--- a/lib/global_registry/exceptions.rb
+++ b/lib/global_registry/exceptions.rb
@@ -1,6 +1,9 @@
 module GlobalRegistry #:nodoc:
+
   class BadRequest < ::RestClient::BadRequest; end
   class ResourceNotFound < ::RestClient::ResourceNotFound; end
   class InternalServerError < ::RestClient::InternalServerError; end
   class OtherError < ::RestClient::Exception; end
+
+  EXCEPTIONS = [BadRequest, ResourceNotFound, InternalServerError, OtherError].freeze
 end

--- a/lib/global_registry/exceptions.rb
+++ b/lib/global_registry/exceptions.rb
@@ -1,5 +1,4 @@
 module GlobalRegistry #:nodoc:
-
   class BadRequest < ::RestClient::BadRequest; end
   class ResourceNotFound < ::RestClient::ResourceNotFound; end
   class InternalServerError < ::RestClient::InternalServerError; end


### PR DESCRIPTION
This will allow applications using this gem to specifically rescue and ignore RestClient exceptions coming from this gem and not all RestClient exceptions.

